### PR TITLE
Add playing card example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ std::optional<char32_t> last_nonascii(std::ranges::view auto str) {
 
 Transcoding strings and throwing a descriptive exception on invalid UTF:
 
-(This example assumes the existence of the `enum_to_string` function from
-[P2996](https://isocpp.org/files/papers/P2996R6.html#enum-to-string))
+(This example assumes the existence of the `enum_to_string` sample function
+from [P2996](https://isocpp.org/files/papers/P2996R6.html#enum-to-string))
 
 ```
 template <typename FromChar, typename ToChar>
@@ -68,6 +68,39 @@ std::basic_string<ToChar> transcode_or_throw(std::basic_string_view<FromChar> in
     }
   }
   return result;
+}
+```
+
+Changing the suits of Unicode playing card characters:
+
+```
+enum class suit : std::uint8_t {
+  spades = 0xA,
+  hearts = 0xB,
+  diamonds = 0xC,
+  clubs = 0xD
+};
+
+// Unicode playing card characters are laid out such that changing the second least
+// significant nibble changes the suit, e.g.
+// U+1F0A1 PLAYING CARD ACE OF SPADES
+// U+1F0B1 PLAYING CARD ACE OF HEARTS
+constexpr char32_t change_playing_card_suit(char32_t card, suit s) {
+  if (U'\N{PLAYING CARD ACE OF SPADES}' <= card && card <= U'\N{PLAYING CARD KING OF CLUBS}') {
+    return (card & ~(0xF << 4)) | (static_cast<std::uint8_t>(s) << 4);
+  }
+  return card;
+}
+
+void change_playing_card_suits() {
+  std::u8string_view const spades = u8"🂡🂢🂣🂤🂥🂦🂧🂨🂩🂪🂫🂭🂮";
+  std::u8string const hearts =
+    spades |
+    to_utf32 |
+    std::views::transform(std::bind_back(change_playing_card_suit, suit::hearts)) |
+    to_utf8 |
+    std::ranges::to<std::u8string>();
+  assert(hearts == u8"🂱🂲🂳🂴🂵🂶🂷🂸🂹🂺🂻🂽🂾");
 }
 ```
 

--- a/paper/P2728.md
+++ b/paper/P2728.md
@@ -112,6 +112,10 @@ monofont: "DejaVu Sans Mono"
 - Replace code examples with new ones reflecting API changes.
 - Provide a reference implementation.
 
+## Changes since R7
+
+- Add playing card example
+
 # Motivation
 
 Unicode is important to many, many users in everyday software. It is not
@@ -192,7 +196,7 @@ std::optional<char32_t> last_nonascii(std::ranges::view auto str) {
 
 ## Transcoding strings and throwing a descriptive exception on invalid UTF
 
-(This example assumes the existence of the `enum_to_string` function from
+(This example assumes the existence of the `enum_to_string` sample function from
 [@P2996R5])
 
 ```cpp
@@ -210,6 +214,39 @@ std::basic_string<ToChar> transcode_or_throw(std::basic_string_view<FromChar> in
     }
   }
   return result;
+}
+```
+
+## Changing the suits of Unicode playing card characters:
+
+```
+enum class suit : std::uint8_t {
+  spades = 0xA,
+  hearts = 0xB,
+  diamonds = 0xC,
+  clubs = 0xD
+};
+
+// Unicode playing card characters are laid out such that changing the second least
+// significant nibble changes the suit, e.g.
+// U+1F0A1 PLAYING CARD ACE OF SPADES
+// U+1F0B1 PLAYING CARD ACE OF HEARTS
+constexpr char32_t change_playing_card_suit(char32_t card, suit s) {
+  if (U'\N{PLAYING CARD ACE OF SPADES}' <= card && card <= U'\N{PLAYING CARD KING OF CLUBS}') {
+    return (card & ~(0xF << 4)) | (static_cast<std::uint8_t>(s) << 4);
+  }
+  return card;
+}
+
+void change_playing_card_suits() {
+  std::u8string_view const spades = u8"🂡🂢🂣🂤🂥🂦🂧🂨🂩🂪🂫🂭🂮";
+  std::u8string const hearts =
+    spades |
+    to_utf32 |
+    std::views::transform(std::bind_back(change_playing_card_suit, suit::hearts)) |
+    to_utf8 |
+    std::ranges::to<std::u8string>();
+  assert(hearts == u8"🂱🂲🂳🂴🂵🂶🂷🂸🂹🂺🂻🂽🂾");
 }
 ```
 


### PR DESCRIPTION
This example provides an example of the kind of transformation that can only be performed on UTF-32 code units and not UTF-8 code units. Changing the second most significant nibble of the underlying code point is intractable on UTF-8 code points but can easily be done with UTF-32.