### PR TITLE
Use iterator_interface instead of proxy_iterator_interface for code_unit_view

### DIFF
--- a/include/utf_view/code_unit_view.hpp
+++ b/include/utf_view/code_unit_view.hpp
@@ -114,10 +114,10 @@ public:
 template <exposition_only_convertible_to_charN_t_view<char8_t> V>
 template <bool Const>
 class as_char8_t_view<V>::exposition_only_iterator
-    : public boost::stl_interfaces::proxy_iterator_interface<
+    : public boost::stl_interfaces::iterator_interface<
           exposition_only_iterator_to_tag_t<
               std::ranges::iterator_t<exposition_only_maybe_const<Const, V>>>,
-          char8_t> {
+          char8_t, char8_t, void, std::ptrdiff_t> {
 public:
   using reference_type = char8_t;
 
@@ -277,10 +277,10 @@ public:
 template <exposition_only_convertible_to_charN_t_view<char16_t> V>
 template <bool Const>
 class as_char16_t_view<V>::exposition_only_iterator
-    : public boost::stl_interfaces::proxy_iterator_interface<
+    : public boost::stl_interfaces::iterator_interface<
           exposition_only_iterator_to_tag_t<
               std::ranges::iterator_t<exposition_only_maybe_const<Const, V>>>,
-          char16_t> {
+          char16_t, char16_t, void, std::ptrdiff_t> {
 public:
   using reference_type = char16_t;
 
@@ -440,10 +440,10 @@ public:
 template <exposition_only_convertible_to_charN_t_view<char32_t> V>
 template <bool Const>
 class as_char32_t_view<V>::exposition_only_iterator
-    : public boost::stl_interfaces::proxy_iterator_interface<
+    : public boost::stl_interfaces::iterator_interface<
           exposition_only_iterator_to_tag_t<
               std::ranges::iterator_t<exposition_only_maybe_const<Const, V>>>,
-          char32_t> {
+          char32_t, char32_t, void, std::ptrdiff_t> {
 public:
   using reference_type = char32_t;
 

--- a/paper/P2728.md
+++ b/paper/P2728.md
@@ -115,6 +115,9 @@ monofont: "DejaVu Sans Mono"
 ## Changes since R7
 
 - Add playing card example
+- Remove iterator_interface from @*utf-iterator*@ and change
+  as_charN_t_view::@*iterator*@ dependency from proxy_iterator_interface to
+  iterator_interface
 
 # Motivation
 
@@ -5611,7 +5614,7 @@ namespace std::uc {
   template<@*convertible-to-charN-t-view*@<char8_t> V>
   template<bool Const>
   class as_char8_t_view<V>::@*iterator*@
-      : public proxy_iterator_interface<@*iterator-to-tag-t*@<ranges::iterator_t<@*maybe-const*@<Const, V>>>, char8_t> {
+      : public iterator_interface<@*iterator-to-tag-t*@<ranges::iterator_t<@*maybe-const*@<Const, V>>>, char8_t, char8_t, void, ptrdiff_t> {
   public:
     using reference_type = char8_t;
 
@@ -5722,7 +5725,7 @@ namespace std::uc {
   template<@*convertible-to-charN-t-view*@<char16_t> V>
   template<bool Const>
   class as_char16_t_view<V>::@*iterator*@
-      : public proxy_iterator_interface<@*iterator-to-tag-t*@<ranges::iterator_t<@*maybe-const*@<Const, V>>>, char16_t> {
+      : public iterator_interface<@*iterator-to-tag-t*@<ranges::iterator_t<@*maybe-const*@<Const, V>>>, char16_t, char16_t, void, ptrdiff_t> {
   public:
     using reference_type = char16_t;
 
@@ -5833,7 +5836,7 @@ namespace std::uc {
   template<@*convertible-to-charN-t-view*@<char32_t> V>
   template<bool Const>
   class as_char32_t_view<V>::@*iterator*@
-      : public proxy_iterator_interface<@*iterator-to-tag-t*@<ranges::iterator_t<@*maybe-const*@<Const, V>>>, char32_t> {
+      : public iterator_interface<@*iterator-to-tag-t*@<ranges::iterator_t<@*maybe-const*@<Const, V>>>, char32_t, char32_t, void, ptrdiff_t> {
   public:
     using reference_type = char32_t;
 


### PR DESCRIPTION
The intent of using proxy_iterator_interface is to provide an operator-> implementation for these iterators, but we don't want one here; there are no member functions on charN_t that could be invoked, and the precedent in std::ranges::transform_view<V,F>::@*iterator*@ is to omit operator->.