### PR TITLE
Add CMake option controlling whether tests are built

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,23 @@ option(
     OFF
 )
 
+# Don't build tests if configuring utf_view as a submodule of another
+# CMake project, unless they explicitly set UTF_VIEW_BUILD_TESTS=TRUE,
+# or they enabled CTest's BUILD_TESTING option
+if ((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME) OR BUILD_TESTING)
+    set(UTF_VIEW_BUILD_TESTS_DEFAULT ON)
+else()
+    set(UTF_VIEW_BUILD_TESTS_DEFAULT OFF)
+endif()
+option(
+  UTF_VIEW_BUILD_TESTS
+  "Enable building tests and test infrastructure. Default: ON. Values: { ON, OFF }."
+  ${UTF_VIEW_BUILD_TESTS_DEFAULT})
+
+# UTF_VIEW_BUILD_TESTS is used solely to configure CTest's BUILD_TESTING option,
+# which is CMake's preferred option for enabling testing when using CTest.
+set(BUILD_TESTING ${UTF_VIEW_BUILD_TESTS})
+
 if (BUILD_TESTING)
   include(CTest)
 endif()


### PR DESCRIPTION
This commit adds a UTF_VIEW_BUILD_TESTS CMake option. The logic around its use is:

- If the user has explicitly set UTF_VIEW_BUILD_TESTS, BUILD_TESTING is set to that value
- Otherwise, if BUILD_TESTING was already set to ON, then it continues to be set to ON
- Otherwise, if this is the top-level CMake project and not a dependency of another project, BUILD_TESTING is set to ON
- Otherwise, BUILD_TESTING is set to OFF

Using BUILD_TESTING to control whether tests are enabled is recommended by CMake in its documentation here:
https://cmake.org/cmake/help/latest/module/CTest.html

This logic is based on a similar option implemented in NVIDIA/stdexec. My commit implementing this logic can be found here:

https://github.com/NVIDIA/stdexec/commit/ee0a962827e9fb1dda29560b0ce3b9056dbaaf17

Additional reasoning can be found here:

https://github.com/NVIDIA/stdexec/pull/1380#issue-2421784880