### PR TITLE
Add CMake option controlling whether tests are built

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,14 +9,16 @@ cmake_minimum_required(VERSION 3.27)
 project(utf_view CXX)
 
 option(
+    UTF_VIEW_BUILD_TESTING
+    "Enable building tests and test infrastructure. Default: ON. Values: { ON, OFF }."
+    ${PROJECT_IS_TOP_LEVEL}
+)
+
+option(
     UTF_VIEW_BUILD_PAPER
     "Enable building paper. Default: OFF. Values: { ON, OFF }."
     OFF
 )
-
-if (BUILD_TESTING)
-  include(CTest)
-endif()
 
 if (NOT TARGET boost_config)
   add_subdirectory(deps/config)
@@ -39,6 +41,7 @@ if (UTF_VIEW_BUILD_PAPER)
   add_subdirectory(paper)
 endif()
 
-if(BUILD_TESTING)
+if (UTF_VIEW_BUILD_TESTING)
+    enable_testing()
     add_subdirectory(tests/utf_view)
 endif()

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ This excerpt from the project's CI script provides an example of building the pr
 
     mkdir "$checkout/build"
     cd "$checkout/build"
-    cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=23 -DBUILD_TESTING=On "$@"
+    cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=23 -DUTF_VIEW_BUILD_TESTING=On "$@"
     cmake --build . --parallel
     ctest -C Debug
 

--- a/ci.sh
+++ b/ci.sh
@@ -7,7 +7,7 @@ function main() {
     local checkout="$PWD"
     mkdir "$checkout/build"
     cd "$checkout/build"
-    cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=23 -DBUILD_TESTING=On "$@"
+    cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=23 -DUTF_VIEW_BUILD_TESTING=On "$@"
     cmake --build . --parallel
     export ASAN_OPTIONS=alloc_dealloc_mismatch=0 # https://github.com/llvm/llvm-project/issues/59432
     ctest -C Debug


### PR DESCRIPTION
This commit eliminates our use of BUILD_TESTING and adds a project-specific UTF_VIEW_BUILD_TESTING CMake option. It avoids including CTest and relies on calls to enable_testing(), which is what Beman repositories do to ensure sufficient granularity.